### PR TITLE
Add swift language specific Package.swift

### DIFF
--- a/Package@swift-4.0.swift
+++ b/Package@swift-4.0.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.0
+// swift-tools-version:4.0
 // HypertextApplicationLanguage Package.swift
 //
 // Copyright © 2017, Roy Ratcliffe, Pioneering Software, United Kingdom

--- a/Package@swift-4.2.swift
+++ b/Package@swift-4.2.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.0
+// swift-tools-version:4.2
 // HypertextApplicationLanguage Package.swift
 //
 // Copyright © 2017, Roy Ratcliffe, Pioneering Software, United Kingdom


### PR DESCRIPTION
These are needed to get around a bug in the Swift Package Manager when compiling with iOS. If a Package is compiled with a version of the language less than 5.0 it gets the minimum deployment values wrong.